### PR TITLE
Multi badge purchase support

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,7 +14,7 @@ module.exports = (purchases, db, cookieSession, billy) => {
     let app = express();
 
     app.use(bodyParser.urlencoded({
-        extended: false
+        extended: true,
     }));
 
     app.use(cookieSession);

--- a/maerkelex/api.js
+++ b/maerkelex/api.js
@@ -6,25 +6,23 @@ function MaerkelexApi(config) {
     };
 }
 
-function get(baseUrl, badgeId, callback) {
+function get(baseUrl, badgeIds, callback) {
     getData(baseUrl, (error, data) => {
         if(error) {
             return callback(error);
         }
-        var badge = data.m.find(m => m.id == badgeId);
-        if(!badge) {
+        var badges = data.m.filter(m => badgeIds.includes(m.id));
+        if(!badges.length || badges.length != badgeIds.length) {
             return callback({
                 type: "NotFound",
-                trace: new Error("Requested badgeId " + badgeId + " wasnt found.")
+                trace: new Error("Some requested badge IDs were not found."),
+                badgeIds: badgeIds.filter((id) => !data.m.some(m => m.id == id)),
             });
         }
-        if(!badge.shippingPrice) {
-            badge.shippingPrice = data.defaultShippingPrice;
-        }
-        if(!badge.internationalShippingPrice) {
-            badge.internationalShippingPrice = data.internationalShippingPrice;
-        }
-        callback(null, badge);
+        callback(null, badges, {
+            domestic: data.defaultShippingPrice,
+            international: data.internationalShippingPrice,
+        });
     });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maerkelex-payment",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "maerkelex-payment",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "ISC",
       "dependencies": {
         "async": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maerkelex-payment",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": "https://github.com/hypesystem/maerkelex-payment",
   "description": "Payment gateway for buying badges from Maerkelex",
   "main": "index.js",

--- a/purchase/startPurchaseEndpoint.js
+++ b/purchase/startPurchaseEndpoint.js
@@ -1,4 +1,3 @@
-var uuid = require("uuid");
 var fs = require("fs");
 var path = require("path");
 var view = fs.readFileSync(path.join(__dirname, "view.html")).toString();


### PR DESCRIPTION
This adds API support for buying multiple badges in a single order.

This is done by replacing the fields `badge` and `count` from the POST request with a `badges` array that contains items with `id` and `count` in them.

Backwards compatible, can be merged no issue.