### PR TITLE
Manual purchase receipt

### DIFF
--- a/admin/app.js
+++ b/admin/app.js
@@ -12,13 +12,19 @@ const postOrderToAccountingEndpoint = require("./accounting/post/endpoint");
 const loginApp = require("./login/app");
 const changePasswordEndpoint = require("./change-password/endpoint");
 const updateOrderInfoEndpoint = require("./updateOrder/endpoint");
+const inputManualReceiptEndpoint = require("./manual-receipt/input-endpoint");
+const createManualReceiptEndpoint = require("./manual-receipt/create-endpoint");
 
-module.exports = (db, purchases, billy) => {
+module.exports = (db, purchases, billy, maerkelex) => {
     let app = express();
 
     let users = Users(db);
 
     app.get("/", authenticate(users), listPurchasesEndpoint(purchases));
+
+    app.get("/manual-receipt", authenticate(users), inputManualReceiptEndpoint(maerkelex));
+    app.post("/manual-receipt", authenticate(users), createManualReceiptEndpoint(purchases));
+
     app.get("/orders", authenticate(users), listOrdersJsonEndpoint(purchases));
     app.get("/orders/:id/mark-dispatched", authenticate(users), markDispatchedEndpoint(purchases));
     app.get("/orders/:id/receipt", authenticate(users), viewReceiptEndpoint(purchases));

--- a/admin/listPurchases/listView.html
+++ b/admin/listPurchases/listView.html
@@ -281,7 +281,7 @@
                 <a href="#" class="option option-all-orders">Alle ordrer</a>
                 <a href="#" class="option option-new-orders selected">Nye ordrer</a>
                 <a href="#" class="option option-sent-orders">Afsendte ordrer</a>
-                <a href="/admin/manual-receipt" class="option">+ Manuel kvittering</a>
+                <a href="/admin/manual-receipt" class="option">Opret kvittering</a>
             </nav>
             <table>
                 <thead>

--- a/admin/listPurchases/listView.html
+++ b/admin/listPurchases/listView.html
@@ -362,7 +362,7 @@
             return entries.map(entry => {
                 return `<tr id="order-${entry.id}">
                     <td class="date-field">${entry.date.replace(" ","<br>")}</td>
-                    <td>${entry.customer}</td>
+                    <td>${entry.customer || 'En kunde'}</td>
                     <td class="status">${translateStatus(entry.status)}<br><span class="status-date">${entry.statusChangeDate || "?"}</span></td>
                     <td>${entry.isPreorder ? 'PRE: ' : ''}${entry.description}</td>
                     <td class="income">${entry.total}</td>
@@ -388,7 +388,7 @@
                         : "") +
                         `<div class="info-container">
                             <strong>Adresse</strong><br>
-                            ${entry.address.replace(/\n/g, '<br>')}<br>
+                            ${entry.address ? entry.address.replace(/\n/g, '<br>') : '-'}<br>
                             <br>
                             <strong>Kontaktinformation</strong><br>
                             Email <a href="mailto:${entry.email}">${entry.email}</a><br>

--- a/admin/listPurchases/listView.html
+++ b/admin/listPurchases/listView.html
@@ -275,11 +275,6 @@
                 <span class="value value-dkk">{{ profit }}</span>
                 <span class="description">Det beløb I har tjent efter moms og Mærkelex' afgift</span>
             </div>
-            <div class="stat">
-                <span class="label">Til gode</span>
-                <span class="value value-dkk">{{ remainder }}</span>
-                <span class="description">Det beløb der fortsat står på jeres konto, som I kan bede om at få udbetalt</span>
-            </div>
         </section>
         <div class="container">
             <nav>

--- a/admin/listPurchases/listView.html
+++ b/admin/listPurchases/listView.html
@@ -281,6 +281,7 @@
                 <a href="#" class="option option-all-orders">Alle ordrer</a>
                 <a href="#" class="option option-new-orders selected">Nye ordrer</a>
                 <a href="#" class="option option-sent-orders">Afsendte ordrer</a>
+                <a href="/admin/manual-receipt" class="option">+ Manuel kvittering</a>
             </nav>
             <table>
                 <thead>

--- a/admin/manual-receipt/create-endpoint.js
+++ b/admin/manual-receipt/create-endpoint.js
@@ -1,0 +1,10 @@
+module.exports = (purchases) => (req, res) => {
+    purchases.createManualReceipt(req.body, (error, result) => {
+        if(error) {
+            console.error("Something went wrong", error);
+            return res.fail(500, "Something went wrong");
+        }
+
+        res.redirect(`/admin/orders/${result.paymentId}/receipt`);
+    });
+};

--- a/admin/manual-receipt/input-endpoint.js
+++ b/admin/manual-receipt/input-endpoint.js
@@ -1,0 +1,17 @@
+const fs = require("fs");
+const path = require("path");
+const inputView = fs.readFileSync(path.join(__dirname, "input-view.html")).toString();
+const mustache = require("mustache");
+
+module.exports = (maerkelex) => (req, res) => {
+    maerkelex.getData((error, data) => {
+        if(error) {
+            console.error("Something went wrong", error);
+            return res.fail(500, "Something went wrong");
+        }
+        res.send(mustache.render(inputView, {
+            ...data,
+            m: data.m.filter((badge) => badge.price || badge.price == 0),
+        }));
+    });
+};

--- a/admin/manual-receipt/input-view.html
+++ b/admin/manual-receipt/input-view.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Create manual receipt</title>
+    </head>
+    <body>
+        <h1>Create manual receipt</h1>
+        <form name="manualReceipt" method="post">
+            Dato: <input type="text" name="date" placeholder="YYYY-MM-DD">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Produkt</th>
+                        <th>Antal</th>
+                        <th>Stykpris</th>
+                        <th>Totalpris</th>
+                    </tr>
+                </thead>
+                <tbody data-product-lines>
+                </tbody>
+                <tbody data-delivery-line>
+                    <tr>
+                        <td colspan="3">
+                            Fragt: 
+                            <select name="delivery">
+                                <option value="domestic" selected>Danmark</option>
+                                <option value="international">Udland</option>
+                                <option value="none">Ingen</option>
+                            </select>
+                        </td>
+                        <td><span data-delivery-cost></span> DKK</td>
+                    </tr>
+                </tbody>
+                <thead>
+                    <tr>
+                        <th colspan="3"></th>
+                        <th><span data-total-cost></span> DKK</th>
+                    </tr>
+                </thead>
+            </table>
+            <button type="submit" name="submit">Opret</button>
+        </form>
+        <script>
+            (function() {
+                const form = document.forms.manualReceipt;
+                const deliverySelect = form.delivery;
+                const deliveryCost = document.querySelector('[data-delivery-cost]');
+                const totalCost = document.querySelector('[data-total-cost]');
+                const productLines = document.querySelector('[data-product-lines]');
+                const model = {
+                    cost: {{ defaultShippingPrice }},
+                    lines: [],
+                };
+
+                form.date.value = (new Date()).toISOString().substring(0, 10);
+
+                deliverySelect.addEventListener('change', (e) => {
+                    if(deliverySelect.value === 'domestic') {
+                        model.cost = {{ defaultShippingPrice }};
+                        onPriceUpdated();
+                        return;
+                    }
+                    if(deliverySelect.value === 'international') {
+                        model.cost = {{ internationalShippingPrice }};
+                        onPriceUpdated();
+                        return;
+                    }
+                    model.cost = 0;
+                    onPriceUpdated();
+                    return;
+                });
+
+                function onPriceUpdated() {
+                    const total = model.cost;
+                    deliveryCost.innerText = model.cost.toFixed(2);
+                    totalCost.innerText = total.toFixed(2);
+                }
+
+                function addLine() {
+                    const line = document.createElement('tr');
+                    line.innerHTML = `
+                        <td>
+                            <select name="badges[${model.lines.length}][id]" data-badge-id>
+                                <option value="">&mdash;</option>
+                                {{ #m }}
+                                    <option value="{{ id }}" data-badge-price="{{ price }}">{{ &name }}</option>
+                                {{ /m }}
+                            </select>
+                        </td>
+                        <td><input type="number" name="badges[${model.lines.length}][count]" data-badge-count value="0"></td>
+                        <td><span data-price>0.00</span> DKK</td>
+                        <td><span data-line-price>0.00</span> DKK</td>
+                    `;
+                    productLines.appendChild(line);
+
+                    const lineModel = { id: "", count: 0, price: 0, totalPrice: 0 };
+                    model.lines.push(lineModel);
+
+                    let firstChange = true;
+                    const badgeSelect = line.querySelector('[data-badge-id]');
+                    const badgeCount = line.querySelector('[data-badge-count]');
+                    const price = line.querySelector('[data-price]');
+                    const linePrice = line.querySelector('[data-line-price]');
+
+                    badgeSelect.addEventListener('change', (e) => {
+                        if(firstChange) {
+                            addLine();
+                            firstChange = false;
+                        }
+
+                        lineModel.id = badgeSelect.value;
+                        lineModel.price = parseFloat(badgeSelect[badgeSelect.selectedIndex].dataset.badgePrice);
+                        lineModel.totalPrice = lineModel.price * lineModel.count;
+                        onLinePriceUpdated();
+                        onPriceUpdated();
+                    });
+
+                    badgeCount.addEventListener('input', (e) => {
+                        lineModel.count = parseInt(badgeCount.value);
+                        lineModel.totalPrice = lineModel.price * lineModel.count;
+                        onLinePriceUpdated();
+                        onPriceUpdated();
+                    });
+
+                    function onLinePriceUpdated() {
+                        console.log("updating lin", lineModel, price, linePrice);
+                        price.innerText = lineModel.price.toFixed(2);
+                        linePrice.innerText = lineModel.totalPrice.toFixed(2);
+                    }
+                }
+
+                addLine();
+                onPriceUpdated();
+
+                form.submit.addEventListener('click', (e) => {
+
+                });
+            })();
+        </script>
+    </body>
+</html>

--- a/app.js
+++ b/app.js
@@ -10,7 +10,7 @@ const badRequestErrorView = fs.readFileSync(path.join(__dirname, "_errors/400.ht
 const mustache = require("mustache");
 const memoryStaticAssetMiddleware = require("./memoryStaticAssetMiddleware/index");
 
-module.exports = (purchases, db, cookieSession, billy) => {
+module.exports = (purchases, db, cookieSession, billy, maerkelex) => {
     let app = express();
 
     app.use(bodyParser.urlencoded({
@@ -56,7 +56,7 @@ module.exports = (purchases, db, cookieSession, billy) => {
 
     app.use("/", purchaseApp(purchases));
     app.get("/", (req, res) => res.redirect("/admin"));
-    app.use("/admin", adminApp(db, purchases, billy));
+    app.use("/admin", adminApp(db, purchases, billy, maerkelex));
     app.use("/assets", memoryStaticAssetMiddleware(path.join(__dirname, "assets")));
 
     return app;

--- a/maerkelex/api.js
+++ b/maerkelex/api.js
@@ -1,8 +1,12 @@
 var request = require("request");
 
+// Bind context to function using `b`
+const b = (fn, ...args) => fn.bind(null, ...args);
+
 function MaerkelexApi(config) {
     return {
-        get: get.bind(this, config.baseUrl)
+        get: b(get, config.baseUrl),
+        getData: b(getData, config.baseUrl),
     };
 }
 

--- a/start.js
+++ b/start.js
@@ -22,7 +22,7 @@ let cookieSessionInstance = cookieSession({
 let purchases = Purchases(maerkelex, paymentGateway, db, mailer, cookieSessionInstance);
 var billy = billyApi(config.billy, purchases);
 
-var app = maerkelexPaymentApp(purchases, db, cookieSessionInstance, billy);
+var app = maerkelexPaymentApp(purchases, db, cookieSessionInstance, billy, maerkelex);
 
 app.listen(config.port);
 


### PR DESCRIPTION
Based on #41 

Adds support for manually entering receipt info and creating a receipt that can be automatically booked into the accounts. Receipt can also be printed as PDF and sent to customers (manually).