### PR TITLE
Remove request dependency

### DIFF
--- a/maerkelex/api.js
+++ b/maerkelex/api.js
@@ -42,7 +42,7 @@ async function get(baseUrl, badgeIds) {
 }
 
 async function getData(baseUrl) {
-    const response = axios.get(baseUrl + "/m.json");
+    const response = await axios.get(baseUrl + "/m.json");
     return response.data;
 }
 

--- a/maerkelex/api.js
+++ b/maerkelex/api.js
@@ -2,7 +2,12 @@ const axios = require("axios");
 
 // Bind context to function using `b`
 const b = (fn, ...args) => fn.bind(null, ...args);
-const cbify = (promise, callback) => promise.then((data) => callback(null, data)).catch(callback);
+const cbify = (asyncFunction, callback) => {
+    return function callbackified() {
+        const promise = asyncFunction.apply(this, arguments);
+        promise.then((data) => callback(null, data)).catch(callback);
+    };
+}
 
 function MaerkelexApi(config) {
     return {

--- a/maerkelex/api.js
+++ b/maerkelex/api.js
@@ -1,52 +1,42 @@
-var request = require("request");
+const axios = require("axios");
 
 // Bind context to function using `b`
 const b = (fn, ...args) => fn.bind(null, ...args);
+const cbify = (promise, callback) => promise.then((data) => callback(null, data)).catch(callback);
 
 function MaerkelexApi(config) {
     return {
-        get: b(get, config.baseUrl),
-        getData: b(getData, config.baseUrl),
+        get: cbify(b(get, config.baseUrl)),
+        getData: cbify(b(getData, config.baseUrl)),
+        getAsync: b(get, config.baseUrl),
+        getDataAsync: b(getData, config.baseUrl),
     };
 }
 
-function get(baseUrl, badgeIds, callback) {
-    getData(baseUrl, (error, data) => {
-        if(error) {
-            return callback(error);
-        }
-        var badges = data.m.filter(m => badgeIds.includes(m.id));
-        if(!badges.length || badges.length != badgeIds.length) {
-            return callback({
-                type: "NotFound",
-                trace: new Error("Some requested badge IDs were not found."),
-                badgeIds: badgeIds.filter((id) => !data.m.some(m => m.id == id)),
-            });
-        }
-        callback(null, badges, {
+async function get(baseUrl, badgeIds) {
+    const data = await getData(baseUrl);
+
+    var badges = data.m.filter(m => badgeIds.includes(m.id));
+    if(!badges.length || badges.length != badgeIds.length) {
+        throw {
+            type: "NotFound",
+            trace: new Error("Some requested badge IDs were not found."),
+            badgeIds: badgeIds.filter((id) => !data.m.some(m => m.id == id)),
+        };
+    }
+
+    return {
+        badges,
+        shipping: {
             domestic: data.defaultShippingPrice,
             international: data.internationalShippingPrice,
-        });
-    });
+        }
+    };
 }
 
-function getData(baseUrl, callback) {
-    request.get(baseUrl + "/m.json", (error, httpResponse, body) => {
-        if(error) {
-            return callback(error);
-        }
-        if(httpResponse.statusCode != 200) {
-            return callback(new Error("Failed to get mærkelex data (non-200 response): " + httpResponse.statusCode));
-        }
-        var json;
-        try {
-            json = JSON.parse(body);
-        }
-        catch(e) {
-            return callback(new Error("Failed to parse json response: " + e));
-        }
-        callback(null, json);
-    });
+async function getData(baseUrl) {
+    const response = axios.get(baseUrl + "/m.json");
+    return response.data;
 }
 
 module.exports = MaerkelexApi;

--- a/maerkelex/api.js
+++ b/maerkelex/api.js
@@ -2,10 +2,12 @@ const axios = require("axios");
 
 // Bind context to function using `b`
 const b = (fn, ...args) => fn.bind(null, ...args);
-const cbify = (asyncFunction, callback) => {
+const cbify = (asyncFunction) => {
     return function callbackified() {
-        const promise = asyncFunction.apply(this, arguments);
-        promise.then((data) => callback(null, data)).catch(callback);
+        const callbackIndex = arguments.length - 1;
+        const callback = arguments[callbackIndex];
+        const promise = asyncFunction.apply(this, Array.prototype.slice.call(arguments, 0, callbackIndex));
+        promise.then((result) => callback(null, result)).catch(callback);
     };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "mustache": "^2.3.0",
         "pg": "^8.7.3",
         "puppeteer": "^2.1.1",
-        "request": "^2.88.2",
         "uuid": "^3.0.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "mustache": "^2.3.0",
     "pg": "^8.7.3",
     "puppeteer": "^2.1.1",
-    "request": "^2.88.2",
     "uuid": "^3.0.1"
   },
   "devDependencies": {

--- a/purchases/index.js
+++ b/purchases/index.js
@@ -44,7 +44,7 @@ function createManualReceipt(maerkelex, db, requestBody, callback) {
     const shippingCategory = requestBody.delivery;
     const date = requestBody.date;
 
-    maerkelex.get(badgeOrder.map((badge) => badge.id), (error, badgeInfos, shipping) => {
+    maerkelex.get(badgeOrder.map((badge) => badge.id), (error, { badges: badgeInfos, shipping }) => {
         if(error && error.type == "NotFound") {
             return callback({
                 type: "InvalidOrder",
@@ -130,7 +130,7 @@ function createManualReceipt(maerkelex, db, requestBody, callback) {
 }
 
 function startPurchase(maerkelex, paymentGateway, db, requestBody, badgeOrder, customerInfo, callback) {
-    maerkelex.get(badgeOrder.map((badge) => badge.id), (error, badgeInfos, shipping) => {
+    maerkelex.get(badgeOrder.map((badge) => badge.id), (error, { badges: badgeInfos, shipping }) => {
         if(error && error.type == "NotFound") {
             return callback({
                 type: "InvalidOrder",


### PR DESCRIPTION
Based on #43 . Removes `request` dependency, replacing it with `axios`. Part of moving us towards async/await syntax over callbacks