### PR TITLE
Use order date for sorting and display if no error

### DIFF
--- a/admin/failures/overview/endpoint.js
+++ b/admin/failures/overview/endpoint.js
@@ -13,20 +13,16 @@ module.exports = (purchases) => (req, res) => {
         let failedOrders = orders
             .filter(x => x.status == "failed" || (x.data.errors && x.data.errors.length))
             .sort((a, b) => {
-                if(!a.data.errors || !a.data.errors.length) {
-                    return -1;
-                }
-                if(!b.data.errors || !b.data.errors.length) {
-                    return 1;
-                }
+                let aLatestTimestamp, bLatestTimestamp;
 
-                const aLatest = a.data.errors[a.data.errors.length - 1];
-                const bLatest = b.data.errors[b.data.errors.length - 1];
-                if(aLatest.at < bLatest.at) {
-                    return -1;
-                }
-                if(aLatest.at > bLatest.at) {
+                !a.data.errors || !a.data.errors.length ? aLatestTimestamp = a.data.viewModel.date : aLatestTimestamp = a.data.errors[a.data.errors.length - 1].at;
+                !b.data.errors || !b.data.errors.length ? bLatestTimestamp = b.data.viewModel.date : bLatestTimestamp = b.data.errors[b.data.errors.length - 1].at;
+
+                if(aLatestTimestamp < bLatestTimestamp) {
                     return 1;
+                }
+                if(aLatestTimestamp > bLatestTimestamp) {
+                    return -1;
                 }
                 return 0;
             })
@@ -34,7 +30,7 @@ module.exports = (purchases) => (req, res) => {
                 const latestError = o.data.errors && o.data.errors.length && o.data.errors[o.data.errors.length - 1];
                 return {
                     id: o.id,
-                    latestErrorAt: latestError && prettifyDate(latestError.at),
+                    latestErrorAt: (latestError && prettifyDate(latestError.at) ) || prettifyDate(o.data.viewModel.date),
                     errors: !latestError ? [] : o.data.errors.reverse().map((error) => {
                         return {
                             at: prettifyDate(error.at),

--- a/admin/failures/overview/endpoint.js
+++ b/admin/failures/overview/endpoint.js
@@ -25,7 +25,7 @@ module.exports = (purchases) => (req, res) => {
                 return 0;
             })
             .map((o) => {
-                const latestError = o.data.errors && o.data.errors.length && o.data.errors[o.data.errors.length - 1];
+                const latestError = getLastElement(o.data.errors);
                 const latestErrorAt = latestError ? prettifyDate(latestError.at) : prettifyDate(o.data.viewModel.date);
                 return {
                     id: o.id,
@@ -51,6 +51,13 @@ function getLatestTimestamp(order){
         return order.data.viewModel.date;
     }
     return order.data.errors[order.data.errors.length - 1].at;
+}
+
+function getLastELement(list) {
+    if(!list || !list.length) {
+        return undefined;
+    }
+    return list[list.length - 1];
 }
 
 function prettifyDate(date) {

--- a/admin/failures/overview/endpoint.js
+++ b/admin/failures/overview/endpoint.js
@@ -26,10 +26,9 @@ module.exports = (purchases) => (req, res) => {
             })
             .map((o) => {
                 const latestError = getLastElement(o.data.errors);
-                const latestErrorAt = latestError ? prettifyDate(latestError.at) : prettifyDate(o.data.viewModel.date);
                 return {
                     id: o.id,
-                    latestErrorAt,
+                    latestErrorAt: prettifyDate(getLatestTimestamp(o)),
                     errors: !latestError ? [] : o.data.errors.reverse().map((error) => {
                         return {
                             at: prettifyDate(error.at),
@@ -47,10 +46,11 @@ module.exports = (purchases) => (req, res) => {
 };
 
 function getLatestTimestamp(order){
-    if(!order.data.errors || !order.data.errors.length){
+    let latestError = getLastElement(order.data.errors);
+    if(!latestError){
         return order.data.viewModel.date;
     }
-    return order.data.errors[order.data.errors.length - 1].at;
+    return latestError.at;
 }
 
 function getLastElement(list) {

--- a/admin/failures/overview/endpoint.js
+++ b/admin/failures/overview/endpoint.js
@@ -13,19 +13,8 @@ module.exports = (purchases) => (req, res) => {
         let failedOrders = orders
             .filter(x => x.status == "failed" || (x.data.errors && x.data.errors.length))
             .sort((a, b) => {
-                let aLatestTimestamp, bLatestTimestamp;
-
-                if(!a.data.errors || !a.data.errors.length){
-                    aLatestTimestamp = a.data.viewModel.date;
-                }else{
-                    aLatestTimestamp = a.data.errors[a.data.errors.length - 1].at;
-                }
-
-                if(!b.data.errors || !b.data.errors.length){
-                    bLatestTimestamp = b.data.viewModel.date
-                }else{
-                    bLatestTimestamp = b.data.errors[b.data.errors.length - 1].at;
-                }
+                const aLatestTimestamp = getLatestTimestamp(a);
+                const bLatestTimestamp = getLatestTimestamp(b);
 
                 if(aLatestTimestamp < bLatestTimestamp) {
                     return 1;
@@ -56,6 +45,13 @@ module.exports = (purchases) => (req, res) => {
         res.send(mustache.render(view, { failedOrders }));
     });
 };
+
+function getLatestTimestamp(order){
+    if(!order.data.errors || !order.data.errors.length){
+        return order.data.viewModel.date;
+    }
+    return order.data.errors[order.data.errors.length - 1].at;
+}
 
 function prettifyDate(date) {
     if(!date) return "";

--- a/admin/failures/overview/endpoint.js
+++ b/admin/failures/overview/endpoint.js
@@ -53,7 +53,7 @@ function getLatestTimestamp(order){
     return order.data.errors[order.data.errors.length - 1].at;
 }
 
-function getLastELement(list) {
+function getLastElement(list) {
     if(!list || !list.length) {
         return undefined;
     }

--- a/admin/failures/overview/endpoint.js
+++ b/admin/failures/overview/endpoint.js
@@ -15,8 +15,17 @@ module.exports = (purchases) => (req, res) => {
             .sort((a, b) => {
                 let aLatestTimestamp, bLatestTimestamp;
 
-                !a.data.errors || !a.data.errors.length ? aLatestTimestamp = a.data.viewModel.date : aLatestTimestamp = a.data.errors[a.data.errors.length - 1].at;
-                !b.data.errors || !b.data.errors.length ? bLatestTimestamp = b.data.viewModel.date : bLatestTimestamp = b.data.errors[b.data.errors.length - 1].at;
+                if(!a.data.errors || !a.data.errors.length){
+                    aLatestTimestamp = a.data.viewModel.date;
+                }else{
+                    aLatestTimestamp = a.data.errors[a.data.errors.length - 1].at;
+                }
+
+                if(!b.data.errors || !b.data.errors.length){
+                    bLatestTimestamp = b.data.viewModel.date
+                }else{
+                    bLatestTimestamp = b.data.errors[b.data.errors.length - 1].at;
+                }
 
                 if(aLatestTimestamp < bLatestTimestamp) {
                     return 1;
@@ -28,9 +37,10 @@ module.exports = (purchases) => (req, res) => {
             })
             .map((o) => {
                 const latestError = o.data.errors && o.data.errors.length && o.data.errors[o.data.errors.length - 1];
+                const latestErrorAt = latestError ? prettifyDate(latestError.at) : prettifyDate(o.data.viewModel.date);
                 return {
                     id: o.id,
-                    latestErrorAt: (latestError && prettifyDate(latestError.at) ) || prettifyDate(o.data.viewModel.date),
+                    latestErrorAt,
                     errors: !latestError ? [] : o.data.errors.reverse().map((error) => {
                         return {
                             at: prettifyDate(error.at),


### PR DESCRIPTION
Displays the date the order was created if there is not an error attached to the failure.
Sorting now uses the order date if there is no error attached to the failure.
Sorting now is newest first. 