### PR TITLE
Update mailgun mustache mailer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "config": "^1.31.0",
         "cookie-session": "^2.0.0-rc.1",
         "express": "^4.17.3",
-        "mailgun-mustache-mailer": "0.0.1",
+        "mailgun-mustache-mailer": "^1.0.2",
         "mime": "^1.4.1",
         "mustache": "^2.3.0",
         "pg": "^8.7.3",
@@ -1660,21 +1660,14 @@
       "dev": true
     },
     "node_modules/mailgun-mustache-mailer": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/mailgun-mustache-mailer/-/mailgun-mustache-mailer-0.0.1.tgz",
-      "integrity": "sha1-5IJsj0TAiPsZhK3IapTvN2kAck0=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mailgun-mustache-mailer/-/mailgun-mustache-mailer-1.0.2.tgz",
+      "integrity": "sha512-4/6KENvO+7XL4PAthhOZQUTSyvvaq7gLwzg0FluvkkIyFlx2UTJdTo+fEPtRUxMClIrWll6xVFCDaNPkKKivTA==",
       "dependencies": {
         "async": "^2.0.1",
         "mustache": "^2.2.1",
-        "request": "^2.75.0",
-        "uuid": "^2.0.3"
+        "request": "^2.75.0"
       }
-    },
-    "node_modules/mailgun-mustache-mailer/node_modules/uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details."
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -4377,21 +4370,13 @@
       "dev": true
     },
     "mailgun-mustache-mailer": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/mailgun-mustache-mailer/-/mailgun-mustache-mailer-0.0.1.tgz",
-      "integrity": "sha1-5IJsj0TAiPsZhK3IapTvN2kAck0=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mailgun-mustache-mailer/-/mailgun-mustache-mailer-1.0.2.tgz",
+      "integrity": "sha512-4/6KENvO+7XL4PAthhOZQUTSyvvaq7gLwzg0FluvkkIyFlx2UTJdTo+fEPtRUxMClIrWll6xVFCDaNPkKKivTA==",
       "requires": {
         "async": "^2.0.1",
         "mustache": "^2.2.1",
-        "request": "^2.75.0",
-        "uuid": "^2.0.3"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
-        }
+        "request": "^2.75.0"
       }
     },
     "media-typer": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "config": "^1.31.0",
     "cookie-session": "^2.0.0-rc.1",
     "express": "^4.17.3",
-    "mailgun-mustache-mailer": "0.0.1",
+    "mailgun-mustache-mailer": "^1.0.2",
     "mime": "^1.4.1",
     "mustache": "^2.3.0",
     "pg": "^8.7.3",

--- a/start.js
+++ b/start.js
@@ -15,7 +15,7 @@ config.braintree.environment = braintree.Environment[config.braintree.environmen
 var maerkelex = maerkelexApi(config.maerkelex);
 var paymentGateway = braintree.connect(config.braintree);
 var db = new Pool(config.postgres);
-var mailer = new MailgunMustacheMailer(config.mailgun);
+var mailer = new MailgunMustacheMailer(config.mailgun, {info: console.log});
 let cookieSessionInstance = cookieSession({
     name: "maerkelex-payment-session-cookie",
     secret: config.sessionTokenSecret


### PR DESCRIPTION
Updates mailgun-mustache-mailer to 1.0.2 from 0.0.1
required interface is the almost the same across versions. A quirk/error makes it so mmm doesn't use its own default making log a required param on the constructor.