### PR TITLE
add amount to object returned by endpoint

### DIFF
--- a/admin/listOrdersJson/endpoint.js
+++ b/admin/listOrdersJson/endpoint.js
@@ -1,6 +1,6 @@
 module.exports = (purchases, maerkelex) => (req, res) => {
     const options = req.query;
-    purchases.list(options, (error, orders) => {
+    purchases.list(options, (error, orders, amountOfOrders) => {
         if(error) {
             console.error("Failed to list purchases", error);
             return res.status(500).send({ error: "failed to list orders" });
@@ -46,7 +46,7 @@ module.exports = (purchases, maerkelex) => (req, res) => {
                         }),
                     };
                 });
-            res.send({orders: result});
+            res.send({orders: result, amount: amountOfOrders});
         });
     });
 };

--- a/purchases/index.js
+++ b/purchases/index.js
@@ -516,7 +516,15 @@ function listPurchases(db, options, callback) {
             console.error("Failed to get purchases to list", error);
             return callback(error);
         }
-        callback(null, result.rows);
+        const orders = result.rows;
+        db.query(`SELECT COUNT(*) FROM purchase `, (error, result) => {
+            if(error) {
+                console.error("Failed to get purchases to list", error);
+                return callback(error);
+            }
+            const amountOfOrders = result.rows[0].count;
+            callback(null, orders, amountOfOrders);
+        })
     });
 }
 


### PR DESCRIPTION
adds a field to the object that is returned by /admin/orders that contains the total amount of orders.
Another step towards the pagination of /admin.
Little unsure if it should query twice(current implementation) or slice a full query, to fit limit and offset.